### PR TITLE
deposit: form authors match with atlantis.cfg

### DIFF
--- a/invenio_demosite/modules/deposit/workflows/article.py
+++ b/invenio_demosite/modules/deposit/workflows/article.py
@@ -77,7 +77,7 @@ class AuthorInlineForm(WebDepositForm):
 
     """Author inline form."""
 
-    name = fields.TextField(
+    full_name = fields.TextField(
         placeholder=_("Family name, First name"),
         widget_classes='form-control',
         # autocomplete=map_result(


### PR DESCRIPTION
* Fix an issue where, the form result variable for authors
  name is not matching with the one in atlantis.cfg, this
  lead to not save authors in the record. (closes #55)

Signed-off-by: Guillaume Lastecoueres <guillaume@tind.io>