### PR TITLE
assets: bootstrap 3.3

### DIFF
--- a/bower-base.json
+++ b/bower-base.json
@@ -2,6 +2,6 @@
     "name": "invenio-demosite",
     "resolutions": {
 	"jquery": "~1.11",
-	"bootstrap": "~3.2"
+	"bootstrap": "~3.3"
     }
 }


### PR DESCRIPTION
* Updates bootstrap to version 3.3 to be in sync with the latest Invenio
  master.

Signed-off-by: Marco Neumann <marco@crepererum.net>

**IMPORTANT: This must be merged into the 2.1.0 release, otherwise the demosite is not working due to bootstrap version conflicts.**