### PR TITLE
docker: working Invenio v2.0 compose configuration

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,15 @@
+.git
+*.gitignore
+
+*.mo
+*.pyc
+*.swp
+*.swo
+*.~
+
+.dockerignore
+Dockerfile
+docker-compose.yml
+docker-compose-dev.yml
+
+Procfile*

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,6 @@ RUN python setup.py compile_catalog
 RUN mkdir -p /code-overlay/src && \
     chown -R invenio:invenio /code-overlay && \
     chown -R root:root /code-overlay/invenio_demosite && \
-    chown -R root:root /code-overlay/scripts && \
     chown -R root:root /code-overlay/setup.* && \
     chown -R root:root /code-overlay/src
 

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -29,9 +29,10 @@ web:
     - DEBUG_TB_INTERCEPT_REDIRECTS=False
     - INVENIO_APP_CONFIG_ENVS=CACHE_REDIS_HOST,CFG_DATABASE_HOST,DEBUG,DEBUG_TB_INTERCEPT_REDIRECTS
   volumes:
-    - ./invenio:/code/invenio:ro
-    - ./docs:/code/docs:rw
-    - ./scripts:/code/scripts:ro
+    - ../invenio/invenio:/code/invenio:ro
+    - ../invenio/docs:/code/docs:rw
+    - ../invenio/scripts:/code/scripts:ro
+    - ./invenio_demosite:/code-overlay/invenio_demosite:ro
     - /code/invenio/base/translations
   links:
     - mysql:db


### PR DESCRIPTION
* FIX Amends `docker-compose` configuration in order to be able to build
  an Invenio 2.0 demo site and populate it with demo records.
  Instructions:

  $ cd ~/private/src/invenio
  $ git checkout maint-2.0
  $ docker build -t invenio:2.0 .
  $ cd ~/private/src/invenio-demosite
  $ git checkout maint-2.0
  $ docker-compose -f docker-compose-dev.yml build
  $ docker-compose -f docker-compose-dev.yml up
  $ # now wait until all daemons are fully up and running
  $ docker exec -i -t -u invenio inveniodemosite_web_1 \
      inveniomanage demosite populate \
      --packages=invenio_demosite.base --yes-i-know
  $ w3m http://127.0.0.1:28080/

* Adds basic `.dockerignore` and amends `Dockerfile` to remove
  unnecessary reference to non-existing `scripts`.

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>