### PR TITLE
docker: sync with invenio master

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@
 # 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
 
 # based on the right Invenio base image
-FROM invenio:2.1
+FROM invenio:latest
 
 # get root rights again
 USER root
@@ -40,6 +40,11 @@ RUN mkdir -p /code-overlay/src && \
     chown -R root:root /code-overlay/invenio_demosite && \
     chown -R root:root /code-overlay/setup.* && \
     chown -R root:root /code-overlay/src
+
+# add volumes
+# do this AFTER `chown`, because otherwise directory permissions are not
+# preserved
+VOLUME /code-overlay
 
 # finally step back again
 USER invenio

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -23,40 +23,55 @@ web:
   ports:
     - "127.0.0.1:28080:28080"
   environment:
+    - ASSETS_DEBUG=True
+    - BROKER_URL=amqp://guest:guest@rabbit:5672//
     - CACHE_REDIS_HOST=cache
+    - CELERY_RESULT_BACKEND=redis://cache:6379/1
     - CFG_DATABASE_HOST=db
+    - "CFG_REDIS_HOSTS={'default': [{'db': 0, 'host': 'cache', 'port': 6379}]}"
     - DEBUG=True
     - DEBUG_TB_INTERCEPT_REDIRECTS=False
-    - INVENIO_APP_CONFIG_ENVS=CACHE_REDIS_HOST,CFG_DATABASE_HOST,DEBUG,DEBUG_TB_INTERCEPT_REDIRECTS
+    - ES_HOSTS=['es']
+    - INVENIO_APP_CONFIG_ENVS=ASSETS_DEBUG,BROKER_URL,CELERY_RESULT_BACKEND,CACHE_REDIS_HOST,CFG_DATABASE_HOST,CFG_REDIS_HOSTS,DEBUG,DEBUG_TB_INTERCEPT_REDIRECTS,ES_HOSTS
   volumes:
     - ../invenio/invenio:/code/invenio:ro
     - ../invenio/docs:/code/docs:rw
     - ../invenio/scripts:/code/scripts:ro
     - ./invenio_demosite:/code-overlay/invenio_demosite:ro
     - /code/invenio/base/translations
+  read_only: true
   links:
+    - elasticsearch:es
     - mysql:db
+    - rabbitmq:rabbit
     - redis:cache
 worker:
   build: .
   command: celery worker --purge -E -A invenio.celery.celery --loglevel=DEBUG
   environment:
-    - BROKER_URL=redis://cache:6379/1
+    - ASSETS_DEBUG=True
+    - BROKER_URL=amqp://guest:guest@rabbit:5672//
     - CACHE_REDIS_HOST=cache
     - CELERY_RESULT_BACKEND=redis://cache:6379/1
     - CFG_DATABASE_HOST=db
+    - "CFG_REDIS_HOSTS={'default': [{'db': 0, 'host': 'cache', 'port': 6379}]}"
     - DEBUG=True
     - DEBUG_TB_INTERCEPT_REDIRECTS=False
-    - INVENIO_APP_CONFIG_ENVS=BROKER_URL,CELERY_RESULT_BACKEND,CACHE_REDIS_HOST,CFG_DATABASE_HOST,DEBUG,DEBUG_TB_INTERCEPT_REDIRECTS
+    - ES_HOSTS=['es']
+    - INVENIO_APP_CONFIG_ENVS=ASSETS_DEBUG,BROKER_URL,CELERY_RESULT_BACKEND,CACHE_REDIS_HOST,CFG_DATABASE_HOST,CFG_REDIS_HOSTS,DEBUG,DEBUG_TB_INTERCEPT_REDIRECTS,ES_HOSTS
   volumes_from:
     - web
+  read_only: true
   links:
+    - elasticsearch:es
     - mysql:db
+    - rabbitmq:rabbit
     - redis:cache
 redis:
   image: redis
   ports:
     - "127.0.0.1:26379:6379"
+  read_only: true
 mysql:
   image: mysql
   ports:
@@ -66,3 +81,20 @@ mysql:
     - MYSQL_USER=invenio
     - MYSQL_PASSWORD=my123p$ss
     - MYSQL_ROOT_PASSWORD=mysecretpassword
+# FIXME detect which volumes are required for `read_only`
+#  volumes:
+#    - /tmp
+#  read_only: true
+rabbitmq:
+  image: rabbitmq:3-management
+  ports:
+    - "127.0.0.1:25672:5672"
+    - "127.0.0.1:25673:15672"
+  read_only: true
+elasticsearch:
+  image: elasticsearch
+  volumes:
+      - ./elasticsearch-docker.yml:/usr/share/elasticsearch/config/elasticsearch.yml:ro
+  ports:
+    - "127.0.0.1:29200:9200"
+  read_only: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,30 +23,37 @@ web:
   ports:
     - "28080:28080"
   environment:
+    - BROKER_URL=amqp://guest:guest@rabbit:5672//
     - CACHE_REDIS_HOST=cache
+    - CELERY_RESULT_BACKEND=redis://cache:6379/1
     - CFG_DATABASE_HOST=db
-    - INVENIO_APP_CONFIG_ENVS=CACHE_REDIS_HOST,CFG_DATABASE_HOST
+    - INVENIO_APP_CONFIG_ENVS=BROKER_URL,CELERY_RESULT_BACKEND,CACHE_REDIS_HOST,CFG_DATABASE_HOST
   volumes:
     - /tmp:/tmp
+  read_only: true
   links:
     - mysql:db
+    - rabbitmq:rabbit
     - redis:cache
 worker:
   build: .
   command: celery worker --purge -E -A invenio.celery.celery --loglevel=DEBUG
   environment:
-    - BROKER_URL=redis://cache:6379/1
+    - BROKER_URL=amqp://guest:guest@rabbit:5672//
     - CACHE_REDIS_HOST=cache
     - CELERY_RESULT_BACKEND=redis://cache:6379/1
     - CFG_DATABASE_HOST=db
     - INVENIO_APP_CONFIG_ENVS=BROKER_URL,CELERY_RESULT_BACKEND,CACHE_REDIS_HOST,CFG_DATABASE_HOST
   volumes_from:
     - web
+  read_only: true
   links:
     - mysql:db
+    - rabbitmq:rabbit
     - redis:cache
 redis:
   image: redis
+  read_only: true
 mysql:
   image: mysql
   environment:
@@ -54,3 +61,9 @@ mysql:
     - MYSQL_USER=invenio
     - MYSQL_PASSWORD=my123p$ss
     - MYSQL_ROOT_PASSWORD=mysecretpassword
+  volumes:
+    - /tmp
+  read_only: true
+rabbitmq:
+  image: rabbitmq:3-management
+  read_only: true

--- a/elasticsearch-docker.yml
+++ b/elasticsearch-docker.yml
@@ -1,0 +1,20 @@
+# This file is part of Invenio Demosite.
+# Copyright (C) 2015 CERN.
+#
+# Invenio is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# Invenio is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Invenio; if not, write to the Free Software Foundation, Inc.,
+# 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+
+cluster.name: invenio
+http.port: 9200
+http.publish_port: 9200


### PR DESCRIPTION
* Adds Elasticsearch.

* Makes docker images read-only.

* Derives master image from `invenio:latest` instead of `invenio:2.1`.

Signed-off-by: Marco Neumann <marco@crepererum.net>

Requires https://github.com/inveniosoftware/invenio/pull/3343